### PR TITLE
Github templates for issuses and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🗣 Subproject discussions 
+    url: https://github.com/camaraproject/ClickToDial/discussions
+    about: Please ask and answer questions here.
+  - name: 📖 CAMARA API Design Guidelines
+    url: https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md
+    about: Please refer to the design guidelines.

--- a/.github/ISSUE_TEMPLATE/issue_correction_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_correction_template.md
@@ -1,0 +1,21 @@
+---
+name: ❗ Correction 👣
+about: Suggest the correction of an issue in API specification or a misalignment with API design guidelines 
+title: ''
+labels: 'correction'
+assignees: ''
+
+---
+
+**Problem description**
+<!-- A clear and concise description of what the problem is.  -->
+
+**Expected behavior**
+<!-- A clear and concise description of what should be changed. -->
+
+
+**Alternative solution**
+<!-- A clear and concise description of any alternative solutions if any. -->
+
+**Additional context**
+<!-- Add any other context of the considered correction. -->

--- a/.github/ISSUE_TEMPLATE/issue_documentation_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_documentation_template.md
@@ -1,0 +1,18 @@
+---
+name: ❕ Documentation 📝
+about: Indicate an issue with API documentation or supplementary documents
+title: ''
+labels: 'documentation'
+assignees: ''
+
+---
+
+**Problem description**
+<!-- A clear and concise description of what the problem is.  -->
+
+**Expected action**
+<!-- A clear and concise description of what should be done. -->
+
+
+**Additional context**
+<!-- Add any other context of the documentation issue e.g. reference documents. -->

--- a/.github/ISSUE_TEMPLATE/issue_enhancement_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_enhancement_template.md
@@ -1,0 +1,20 @@
+---
+name: 💡 Enhancement 🌟
+about: Suggest an idea for a new API feature or pose a question on directions for API evolution
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Problem description**
+<!-- A clear and concise description of what the problem is.  -->
+
+**Possible evolution**
+<!-- A clear and concise description of what can be modified. -->
+
+**Alternative solution**
+<!-- A clear and concise description of any alternative solutions or features if any -->
+
+**Additional context**
+<!-- Add any other context of the considered enhancement. -->

--- a/.github/ISSUE_TEMPLATE/issue_pm_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_pm_template.md
@@ -1,0 +1,18 @@
+---
+name: ☁ Subproject management 🎂
+about: Indicate an issue with subproject repository or release management
+title: ''
+labels: 'subproject management'
+assignees: ''
+
+---
+
+**Problem description**
+<!-- A clear and concise description of what the problem is.  -->
+
+**Expected action**
+<!-- A clear and concise description of what should be done. -->
+
+
+**Additional context**
+<!-- Add any other context of the management issue e.g. reference documents. -->

--- a/.github/ISSUE_TEMPLATE/issue_tests_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_tests_template.md
@@ -1,0 +1,18 @@
+---
+name: ⁉ Tests 🔎
+about: Indicate an issue with API tests
+title: ''
+labels: 'tests'
+assignees: ''
+
+---
+
+**Problem description**
+<!-- A clear and concise description of what the problem is.  -->
+
+**Expected action**
+<!-- A clear and concise description of what should be done. -->
+
+
+**Additional context**
+<!-- Add any other context of the documentation issue e.g. logs, reference documents. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+#### What type of PR is this?
+
+Add one of the following kinds:
+* bug
+* correction
+* enhancement/feature
+* cleanup
+* documentation
+* subproject management
+* tests
+
+
+#### What this PR does / why we need it:
+
+
+
+
+#### Which issue(s) this PR fixes:
+
+<!-- Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
+
+Fixes #
+
+#### Special notes for reviewers:
+
+
+
+#### Changelog input
+
+```
+ release-note
+
+```
+
+#### Additional documentation 
+
+This section can be blank.
+
+
+
+```
+docs
+
+```


### PR DESCRIPTION
**What type of PR is this?**
    subproject management

**What this PR does / why we need it:**

To achieve uniformity across sub projects on using Github templates as indicated in https://github.com/camaraproject/Governance/issues/98  the agreed template files are added.

**Changelog input**

```
Github templates added to repository
```

**Additional documentation**

[Using templates for Issues and Pull Request for CAMARA repositories](https://github.com/camaraproject/Commonalities/blob/main/documentation/Issue%20and%20PR%20template%20Howto.md)