### PR TITLE
Update ClickToDial Spring26 M4 release plan baseline

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,17 +16,17 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.2
+  target_release_tag: r1.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
-  identity_consent_management_release: r4.1
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: click-to-dial
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - YadingFang
       - Wojiaozhenghao


### PR DESCRIPTION
## What

Update the ClickToDial `release-plan.yaml` metadata baseline for Spring26 M4.

This metadata-only PR updates the planned release metadata from the existing r1.2 rc baseline to the Spring26 M4 public-planning baseline:

- target release tag: `r1.3`
- target release type: `public-release`
- Commonalities dependency: `r4.2`
- Identity and Consent Management dependency: `r4.2`
- ClickToDial API status: `public`

## Why

PR #91 aligns the ClickToDial OAS with Commonalities r4.2 / 0.8.0-rc.2, but CAMARA Validation v1 reports:

`[P-101] x-camara-commonalities version mismatch`

The validation requires the OAS `x-camara-commonalities` version and the `release-plan.yaml` Commonalities release tag to match.

This PR establishes the metadata baseline first, while keeping the OAS/test technical changes in PR #91.

## Scope

This PR only modifies:

- `release-plan.yaml`

## Follow-up

After this PR is merged:

1. PR #91 should be updated/rebased onto the latest `main`.
2. CAMARA Validation should be re-run on PR #91.
3. If P-101 disappears and only non-blocking warnings/hints remain, PR #91 can proceed to technical review.
4. The actual publication flow must still wait for the appropriate Release Issue step and must not start until `/create-snapshot` is intentionally executed.

## Validation

- [x] `git diff --check`
- [x] Confirmed only `release-plan.yaml` is modified
- [ ] CAMARA Validation green or findings reviewed
