### PR TITLE
Change ClickToDial r1.3 release plan back to rc

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: public-release
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: click-to-dial
     target_api_version: 0.1.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - YadingFang
       - Wojiaozhenghao


### PR DESCRIPTION
## What

Change the ClickToDial r1.3 Spring26 release plan from public release back to release candidate.

## Why

Per Herbert's comment in #94, Commonalities r4.2 is the second release candidate of Commonalities and therefore cannot yet be used to create a Spring26 public release.

ClickToDial should create a second release candidate release first, based on:

- Commonalities r4.2
- ICM r4.2

The later public release can be prepared when Commonalities r4.3 is available.

## Changes

- Change `target_release_type` from `public-release` to `pre-release-rc`
- Change ClickToDial `target_api_status` from `public` to `rc`
- Keep `target_release_tag` as `r1.3`
- Keep Commonalities dependency as `r4.2`
- Keep ICM dependency as `r4.2`


## Follow-up

After this PR is merged:

1. Consider a small follow-up cleanup PR for remaining non-blocking schema naming warnings, especially PascalCase schema names such as `sink` -> `Sink`.
2. Once the repository is ready, create the second release candidate snapshot from Issue #94 or the updated release issue state.
3. Do not proceed to public release until RM/Commonalities confirms that the appropriate Commonalities public baseline is available.

## Validation

- [x] `git diff --check`
- [x] Confirmed only `release-plan.yaml` changed
- [x] CAMARA Validation green or findings reviewed
