### PR TITLE
Prepare ClickToDial Spring26 public release plan

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,16 +16,16 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.3
+  target_release_tag: r1.4
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: click-to-dial
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - YadingFang
       - Wojiaozhenghao


### PR DESCRIPTION
#### What type of PR is this?

subproject management

#### What this PR does / why we need it:

This PR updates the ClickToDial release plan for the Spring26 public release, following #101.

It declares:
- target release tag: r1.4
- target release type: public-release
- Commonalities dependency: r4.3
- ICM dependency: r4.2
- ClickToDial API status: public

This is a release-plan-only PR, as required by CAMARA validation.

#### Which issue(s) this PR fixes:

Related to #101

#### Special notes for reviewers:

This PR modifies only release-plan.yaml.

The technical OAS/common alignment is handled separately in #102.
