### PR TITLE
Add enhanced ClickToDial rainy-day test scenarios

### DIFF
--- a/code/Test_definitions/click-to-dial-createCall.feature
+++ b/code/Test_definitions/click-to-dial-createCall.feature
@@ -45,7 +45,7 @@ Feature: CAMARA Click to Dial API, vwip - Operation createCall
     And an event is received at the address of the request property "$.sink"
     And the event header "Authorization" is set to "Bearer " + the value of the request property "$.sinkCredential.accessToken"
     And the event header "Content-Type" is "application/cloudevents+json"
-    And the event body complies with the OAS schema at "#/components/schemas/EventCTDStatusChanged"
+    And the event body complies with the OAS schema at "#/components/schemas/CallStatusChangedEvent"
 
   @createcall_event_notification
   Scenario: Event body fields follow ClickToDial status rules
@@ -71,15 +71,27 @@ Feature: CAMARA Click to Dial API, vwip - Operation createCall
       | $.data.callDuration    | present iff state="disconnected"                                                       |
       | $.data.timestamp       | time of state change                                                                   |
 
-  @createcall_failure_missing_fields
-  Scenario: Fail to initiate call due to missing required fields in createCall request
-    And the request property "$.caller" is removed from the request body
+  @createcall_failure_missing_caller
+  Scenario: Fail to initiate call due to missing caller in createCall request
+    Given the request property "$.caller" is removed from the request body
     And the request property "$.callee" is set to a valid callee number in E.164 format
     When the request "createCall" is sent
     Then the response status code is 400
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @createcall_failure_missing_callee
+  Scenario: Fail to initiate call due to missing callee in createCall request
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee" is removed from the request body
+    When the request "createCall" is sent
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
 
   @createcall_failure_authentication
   Scenario: Fail to initiate call due to authentication failure in createCall request
@@ -91,13 +103,98 @@ Feature: CAMARA Click to Dial API, vwip - Operation createCall
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
 
   @createcall_failure_invalid_caller
   Scenario: Fail to initiate call due to invalid caller number format in createCall request
-    And the request property "$.caller" is set to an invalid caller number (not E.164)
+    Given the request property "$.caller.number" is set to an invalid phone number (not in E.164 format)
     And the request property "$.callee" is set to a valid callee number in E.164 format
     When the request "createCall" is sent
     Then the response status code is 422
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.status" is 422
+    And the response property "$.code" is "INVALID_PHONE_NUMBER"
+
+  @createcall_failure_invalid_callee
+  Scenario: Fail to initiate call due to invalid callee number format in createCall request
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee.number" is set to an invalid phone number (not in E.164 format)
+    When the request "createCall" is sent
+    Then the response status code is 422
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "INVALID_PHONE_NUMBER"
+
+  @createcall_failure_same_caller_callee
+  Scenario: Fail to initiate call when caller and callee numbers are the same
+    Given the request property "$.caller.number" is set to "+34666666666"
+    And the request property "$.callee.number" is set to "+34666666666"
+    When the request "createCall" is sent
+    Then the response status code is 422
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "SAME_CALLER_CALLEE"
+
+  @createcall_failure_unknown_property
+  Scenario: Fail to initiate call due to unknown additional property in request body
+    Given the request property "$.unknownProperty" is set to "someValue"
+    And the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee" is set to a valid callee number in E.164 format
+    When the request "createCall" is sent
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @createcall_failure_recording_not_supported
+  Scenario: Fail to initiate call when recording is requested but not supported
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee" is set to a valid callee number in E.164 format
+    And the request property "$.recordingEnabled" is set to true
+    And recording is not supported for the requested call
+    When the request "createCall" is sent
+    Then the response status code is 422
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "RECORDING_NOT_SUPPORTED"
+
+  @createcall_failure_caller_not_available
+  Scenario: Fail to initiate call when the caller is not available
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the caller number is not available or not allowed to start a call
+    And the request property "$.callee" is set to a valid callee number in E.164 format
+    When the request "createCall" is sent
+    Then the response status code is 422
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "CALLER_NOT_AVAILABLE"
+
+  @createcall_failure_callee_not_available
+  Scenario: Fail to initiate call when the callee is not available
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee" is set to a valid callee number in E.164 format
+    And the callee number is not available or not allowed to receive a call
+    When the request "createCall" is sent
+    Then the response status code is 422
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "CALLEE_NOT_AVAILABLE"
+
+  @createcall_failure_invalid_sink
+  Scenario: Fail to initiate call due to invalid sink URI
+    Given the request property "$.caller" is set to a valid caller number in E.164 format
+    And the request property "$.callee" is set to a valid callee number in E.164 format
+    And the request property "$.sink" is set to an invalid URI
+    When the request "createCall" is sent
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"

--- a/code/Test_definitions/click-to-dial-createCall.feature
+++ b/code/Test_definitions/click-to-dial-createCall.feature
@@ -63,8 +63,8 @@ Feature: CAMARA Click to Dial API, vwip - Operation createCall
       | $.id                   | unique per event                                                                       |
       | $.type                 | = "org.camaraproject.click-to-dial.v0.status-changed"                                  |
       | $.data.callId          | = createCall response property "$.callId"                                              |
-      | $.data.caller          | = createCall request property "$.caller"                                               |
-      | $.data.callee          | = createCall request property "$.callee"                                               |
+      | $.data.caller          | = createCall request property "$.caller.number"                                        |
+      | $.data.callee          | = createCall request property "$.callee.number"                                        |
       | $.data.status.state    | in [initiating, callingCaller, callingCallee, connected, disconnected, failed]         |
       | $.data.status.reason   | present iff state="disconnected" and in [hangUp, callerBusy, callerNoAnswer, callerFailure, callerAbandon, calleeBusy, calleeNoAnswer, calleeFailure, other] |
       | $.data.recordingResult | optional; if present, in [success, noRecord, fail]                                     |

--- a/code/Test_definitions/click-to-dial-getCall.feature
+++ b/code/Test_definitions/click-to-dial-getCall.feature
@@ -26,37 +26,44 @@ Feature: CAMARA Click to Dial API, vwip - Operation getCall
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/Call"
 
-  @getcall_failure_invalid_request
-  Scenario: Fail to get call details due to invalid request
-    Given an invalid request with missing or malformed path parameter
+  @getcall_failure_malformed_callid
+  Scenario: Fail to get call details due to malformed callId path parameter
+    Given the request path parameter "callId" is set to a value that does not comply with the CallId schema
     When the request "getCall" is sent
     Then the response status code is 400
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
 
   @getcall_failure_authentication
-  Scenario: Fail to get call details due to authentication failure
+  Scenario: Fail to get call details due to invalid or missing token
     Given an invalid or missing authentication token for the service
     And the request path parameter "callId" is set to a valid call identifier
     When the request "getCall" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
 
   @getcall_failure_authorization
-  Scenario: Fail to get call details due to authorization failure
+  Scenario: Fail to get call details due to insufficient permission
     Given a valid authentication token with insufficient permissions
     And the request path parameter "callId" is set to a valid call identifier
     When the request "getCall" is sent
     Then the response status code is 403
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
 
-  @getcall_failure_invalid_callidentifier
-  Scenario: Fail to get call details due to unknown call identifier
-    Given an invalid call identifier
-    And the request path parameter "callId" is set to that identifier
+  @getcall_failure_unknown_callid
+  Scenario: Fail to get call details due to well-formed but unknown callId
+    Given the request path parameter "callId" is set to a well-formed callId that does not exist in the system
     When the request "getCall" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/click-to-dial-getRecording.feature
+++ b/code/Test_definitions/click-to-dial-getRecording.feature
@@ -28,7 +28,6 @@ Feature: CAMARA Click to Dial API, vwip - Operation getRecording
     And the response property "$.callId" has the same value as the request path parameter "callId"
     And the response property "$.content" exists
     And the response property "$.contentType" is "audio/wav" or "audio/mp3" or "audio/mpeg" or "audio/ogg"
-    And the response property "$.generatedAt" exists
 
   @getrecording_failure_malformed_callid
   Scenario: Fail to download recording due to malformed callId path parameter

--- a/code/Test_definitions/click-to-dial-getRecording.feature
+++ b/code/Test_definitions/click-to-dial-getRecording.feature
@@ -30,36 +30,55 @@ Feature: CAMARA Click to Dial API, vwip - Operation getRecording
     And the response property "$.contentType" is "audio/wav" or "audio/mp3" or "audio/mpeg" or "audio/ogg"
     And the response property "$.generatedAt" exists
 
-  @getrecording_failure_missing_callid
-  Scenario: Fail to download recording due to missing callId in getRecording request
+  @getrecording_failure_malformed_callid
+  Scenario: Fail to download recording due to malformed callId path parameter
+    Given the request path parameter "callId" is set to a value that does not comply with the CallId schema
     When the request "getRecording" is sent
     Then the response status code is 400
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
 
   @getrecording_failure_authentication
-  Scenario: Fail to download recording due to authentication failure in getRecording request
+  Scenario: Fail to download recording due to invalid or missing token
     Given an invalid or missing authentication token for the service
     And the request path parameter "callId" is set to a valid call identifier
     When the request "getRecording" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
 
-  @getrecording_failure_invalid_callidentifier
-  Scenario: Fail to download recording due to invalid call identifier in getRecording request
-    Given an invalid call identifier
+  @getrecording_failure_authorization
+  Scenario: Fail to download recording due to insufficient permission
+    Given a valid authentication token with insufficient permissions
+    And the request path parameter "callId" is set to a valid call identifier
+    When the request "getRecording" is sent
+    Then the response status code is 403
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+
+  @getrecording_failure_unknown_callid
+  Scenario: Fail to download recording due to well-formed but unknown callId
+    Given the request path parameter "callId" is set to a well-formed callId that does not exist in the system
+    When the request "getRecording" is sent
+    Then the response status code is 404
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"
+
+  @getrecording_failure_no_recording
+  Scenario: Fail to download recording because it is not available for a valid call
+    Given a valid call identifier for a call with no available recording
     And the request path parameter "callId" is set to that identifier
     When the request "getRecording" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
-
-  @getrecording_failure_not_found
-  Scenario: Fail to download recording because it is not available
-    Given a call identifier with no available recording
-    And the request path parameter "callId" is set to that identifier
-    When the request "getRecording" is sent
-    Then the response status code is 404
-    And the response header "Content-Type" is "application/json"
-    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/click-to-dial-terminateCall.feature
+++ b/code/Test_definitions/click-to-dial-terminateCall.feature
@@ -23,36 +23,54 @@ Feature: CAMARA Click to Dial API, vwip - Operation terminateCall
     When the request "terminateCall" is sent
     Then the response status code is 204
 
-  @terminatecall_failure_missing_callid
-  Scenario: Fail to terminate call due to missing callId path parameter
+  @terminatecall_failure_malformed_callid
+  Scenario: Fail to terminate call due to malformed callId path parameter
+    Given the request path parameter "callId" is set to a value that does not comply with the CallId schema
     When the request "terminateCall" is sent
     Then the response status code is 400
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
 
   @terminatecall_failure_authentication
-  Scenario: Fail to terminate call due to authentication failure
+  Scenario: Fail to terminate call due to invalid or missing token
     Given an invalid or missing authentication token for the service
     And the request path parameter "callId" is set to a valid call identifier
     When the request "terminateCall" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
 
-  @terminatecall_failure_invalid_callidentifier
-  Scenario: Fail to terminate call due to invalid call identifier
-    Given an invalid call identifier
-    And the request path parameter "callId" is set to that identifier
+  @terminatecall_failure_authorization
+  Scenario: Fail to terminate call due to insufficient permission
+    Given a valid authentication token with insufficient permissions
+    And the request path parameter "callId" is set to a valid call identifier
+    When the request "terminateCall" is sent
+    Then the response status code is 403
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+
+  @terminatecall_failure_unknown_callid
+  Scenario: Fail to terminate call due to well-formed but unknown callId
+    Given the request path parameter "callId" is set to a well-formed callId that does not exist in the system
     When the request "terminateCall" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"
 
   @terminatecall_failure_conflict
   Scenario: Fail to terminate call due to conflicting state
-    Given a call identifier for a call that cannot be terminated (already ended or conflicting state)
+    Given a call identifier for a call in a state that cannot be terminated (already ended or conflicting state)
     And the request path parameter "callId" is set to that identifier
     When the request "terminateCall" is sent
     Then the response status code is 409
     And the response header "Content-Type" is "application/json"
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 409


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

This PR enhances and extends the Gherkin test definitions for ClickToDial 0.2.0-rc Sync26 readiness, specifically focusing on enhanced rainy-day scenarios.

* Fixes stale callback schema reference in `click-to-dial-createCall.feature` from `EventCTDStatusChanged` to `CallStatusChangedEvent`.
* Enhances `createCall` rainy-day scenarios covering missing fields, invalid/same caller/callee format, unknown properties, unsupported recording, unavailable caller/callee, and invalid sink URI.
* Refines callback event validation to ensure it checks Content-Type, event body, type, data.callId matching, and optional/conditional fields.
* Enhances `getCall` rainy-day scenarios covering malformed callId, unknown callId, insufficient permission, and invalid/missing token.
* Enhances `terminateCall` rainy-day scenarios covering malformed callId, unknown callId, insufficient permission, and conflict state (asserting 409 status code).
* Enhances `getRecording` rainy-day scenarios covering malformed callId, unknown callId, no available recording, invalid/missing token, and insufficient permission.

#### Which issue(s) this PR fixes:

Not applicable.

#### Special notes for reviewers:

The test definitions are implementation-neutral and do not introduce error codes beyond the current OAS-defined response codes.

