### PR TITLE
docs: correct client authentication example to private_key_jwt in ClickToDial API doc

### DIFF
--- a/documentation/API_documentation/click-to-dial_API.md
+++ b/documentation/API_documentation/click-to-dial_API.md
@@ -12,10 +12,16 @@ The Click to Dial API provides a standardized interface to initiate and manage v
 
 ### 2.1 Prerequisites
 
-- **Authentication**: Obtain an OpenID Connect access token from your API provider.
+- **Authentication**: Obtain an OpenID Connect access token from your API provider's authorization server, then send it as a Bearer token on every request. The `security` section of the OpenAPI definition uses the `openId` scheme; each operation lists the scope it requires (for example `click-to-dial:calls:create` for `POST /calls`).
+
+  Per the CAMARA Security & Interoperability Profile, the API Consumer authenticates to the authorization server using `private_key_jwt` (a signed JWT client assertion) rather than a shared `client_secret`. The grant type and any additional parameters are agreed with the provider at onboarding, so the exact token request depends on that agreement:
 
   ```bash
-  curl -X POST "{openid_token_url}" -d "grant_type=client_credentials&client_id={your_id}&client_secret={your_secret}"
+  curl -X POST "{openid_token_url}" \
+       -d "client_id={your_id}" \
+       -d "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+       -d "client_assertion={signed_jwt}" \
+       -d "scope=click-to-dial:calls:create"
   ```
 
 ### 2.2 Quick Try
@@ -94,7 +100,7 @@ curl -X GET "{apiRoot}/calls/{callId}/recording" \
 
 ## 3\. Authentication and Authorization
 
-This API uses **OpenID Connect** for authentication and authorization. Obtain your access token from your provider and use it in the Authorization header for all API requests.
+This API uses **OpenID Connect** for authentication and authorization, following the CAMARA Security & Interoperability Profile. The API Consumer authenticates to the authorization server using `private_key_jwt` (a signed JWT client assertion); a shared `client_secret` is not an accepted client-authentication method. Obtain your access token from your provider and use it in the Authorization header for all API requests. Each operation requires the scope declared for it in the OpenAPI `security` section.
 
 ## 4\. API Documentation
 
@@ -134,6 +140,7 @@ The call session progresses through the following states (representing the `stat
 | callee         | Called party number (E.164, with "+")               | Yes      | "+87654321"                  |
 | sink           | (Optional) Callback URL for status notifications    | No       | `<https://yourapp.com/notify>` |
 | sinkCredential | (Optional) Callback authentication info (see below) | No       | (see below)                  |
+| recordingEnabled | (Optional) Request call recording for this call   | No       | `true`                       |
 
 ##### sinkCredential (for `ACCESSTOKEN` type)
 
@@ -231,10 +238,10 @@ Note: Additional common CAMARA error responses may be defined in the `CAMARA_com
 ## CloudEvent delivery notes
 
 - Providers MUST send status notifications as CloudEvents in structured mode. The HTTP header must be `Content-Type: application/cloudevents+json`.
-- The CloudEvent MUST include the attributes: `id`, `source`, `type`, `specversion`, and `time`.
-- The CloudEvent attribute `datacontenttype` MUST be `application/json` for the `data` payload.
+- The CloudEvent MUST include the attributes required by `CloudEvent` in the OpenAPI definition: `id`, `source`, `specversion`, `type`, and `time`.
+- When the `datacontenttype` attribute is present, it describes the `data` payload and is `application/json` for this API.
 
-The CloudEvent `data` payload for Click-to-Dial `CallStatusChangedEvent` includes `callId`, `caller`, `callee`, `timestamp` and `status` (where `status` is an object with `state` and optional `reason`). Providers MUST set `datacontenttype` to `application/json`.
+The CloudEvent `data` payload for Click-to-Dial `CallStatusChangedEvent` includes `callId`, `caller`, `callee`, `timestamp` and `status` (where `status` is an object with `state` and optional `reason`). Events for this API set `datacontenttype` to `application/json`, matching the `data` payload.
 
 Example CloudEvent (structured mode) — `CALL_STATUS_CHANGED_EXAMPLE` from the OpenAPI spec:
 
@@ -250,7 +257,7 @@ Example CloudEvent (structured mode) — `CALL_STATUS_CHANGED_EXAMPLE` from the 
   "data": {
     "callId": "123e4567-e89b-12d3-a456-426614174000",
     "caller": "+12345678",
-    "callee": "+12345678",
+    "callee": "+87654321",
     "status": {
       "state": "disconnected",
       "reason": "hangUp"


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

The supplementary API documentation `documentation/API_documentation/click-to-dial_API.md` showed token acquisition with `grant_type=client_credentials&client_id=...&client_secret=...`. A shared `client_secret` is not an accepted client-authentication method under the CAMARA Security & Interoperability Profile, which requires `private_key_jwt` (a signed JWT client assertion). The normative OpenAPI definition (`code/API_definitions/click-to-dial.yaml`) is already correct; these changes bring the doc asset in line with it.

Changes, all in the doc file:

- Sections 2.1 and 3: replace the `client_secret` example with a `private_key_jwt` (`client_assertion`) request, and reference the `openId` security scheme and per-operation scopes from the OpenAPI definition instead of hard-coding a grant type.
- Section 4.2.3: add the `recordingEnabled` row to the Initiation Request attribute table (it is part of `CreateCallRequest` and already used in the document's examples).
- CloudEvent delivery notes: state the required attribute set as `id`, `source`, `specversion`, `type`, `time` (matching the OpenAPI `CloudEvent`) rather than being stricter than the spec, and describe `datacontenttype` as present-and-`application/json` for this API's events.
- CloudEvent example: change the identical `caller`/`callee` (`+12345678`) to distinct numbers so it no longer contradicts the `SAME_CALLER_CALLEE` (422) rule.

The version/release-notes items noted in the issue are left to release tooling, which owns the `wip` -> version stamping on this branch.

#### Which issue(s) this PR fixes:

Fixes #113

#### Special notes for reviewers:

Only the markdown doc file is touched; the OpenAPI definition is unchanged. The `CALL_STATUS_CHANGED_EXAMPLE` in the OpenAPI spec has the same identical-number issue and could be updated in a follow-up.

#### Changelog input

```
 release-note
Correct the ClickToDial API documentation authentication example to use private_key_jwt and fix related stale content.
```

#### Additional documentation 

This section can be blank.

```
docs

```
